### PR TITLE
use the simde header library for non-x86 compatability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "simde"]
+	path = include/simde
+	url = https://github.com/simd-everywhere/simde-no-tests

--- a/src/align/cssw/ssw.c
+++ b/src/align/cssw/ssw.c
@@ -35,7 +35,8 @@
  *
  */
 
-#include <emmintrin.h>
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/align/cssw/ssw.h
+++ b/src/align/cssw/ssw.h
@@ -11,7 +11,8 @@
 #ifndef SSW_H
 #define SSW_H
 
-#include <emmintrin.h>
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse2.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Hello, this is a patch that we use for the Debian package of pbcopper to enable building on non-x86 systems like arm64, ppc64el, and s390x